### PR TITLE
Load all resource on https connection

### DIFF
--- a/barrel.html
+++ b/barrel.html
@@ -9,8 +9,8 @@
 		<link rel="stylesheet" href="css/main.css">
 		<link href="css/polyglot-language-switcher-2.css" rel="stylesheet">
 		<link rel="shortcut icon" type="image/ico" href="favicon.ico">
-		<link href='http://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+		<link href='https://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.min.js"></script>
 		<script src="app/lib/moment.min.js"></script>

--- a/contact.html
+++ b/contact.html
@@ -9,8 +9,8 @@
 		<link rel="stylesheet" href="css/main.css">
 		<link href="css/polyglot-language-switcher-2.css" rel="stylesheet">
 		<link rel="shortcut icon" type="image/ico" href="favicon.ico">
-		<link href='http://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+		<link href='https://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.min.js"></script>
 		<script src="app/lib/moment.min.js"></script>

--- a/contact_layout.html
+++ b/contact_layout.html
@@ -9,8 +9,8 @@
 		<link rel="stylesheet" href="css/contact.css">
 		<link href="css/polyglot-language-switcher-2.css" rel="stylesheet">
 		<link rel="shortcut icon" type="image/ico" href="favicon.ico">
-		<link href='http://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+		<link href='https://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 		<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 		<script src="app/app2.js"></script>

--- a/event-jpn.html
+++ b/event-jpn.html
@@ -9,8 +9,8 @@
 		<link rel="stylesheet" href="css/main.css">
 		<link href="css/polyglot-language-switcher-2.css" rel="stylesheet">
 		<link rel="shortcut icon" type="image/ico" href="favicon.ico">
-		<link href='http://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+		<link href='https://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.min.js"></script>
 		<script src="app/lib/moment.min.js"></script>

--- a/event.html
+++ b/event.html
@@ -9,8 +9,8 @@
 		<link rel="stylesheet" href="css/main.css">
 		<link href="css/polyglot-language-switcher-2.css" rel="stylesheet">
 		<link rel="shortcut icon" type="image/ico" href="favicon.ico">
-		<link href='http://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+		<link href='https://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.min.js"></script>
 		<script src="app/lib/moment.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 		<link rel="stylesheet" href="css/main.css">
 		<link href="css/polyglot-language-switcher-2.css" rel="stylesheet">
 		<link rel="shortcut icon" type="image/ico" href="favicon.ico">
-		<link href='http://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+		<link href='https://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.min.js"></script>
 		<script src="app/lib/moment.min.js"></script>

--- a/settings.html
+++ b/settings.html
@@ -9,8 +9,8 @@
 		<link rel="stylesheet" href="css/main.css">
 		<link href="css/polyglot-language-switcher-2.css" rel="stylesheet">
 		<link rel="shortcut icon" type="image/ico" href="favicon.ico">
-		<link href='http://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+		<link href='https://fonts.googleapis.com/css?family=Squada+One|Lora' rel='stylesheet' type='text/css'>
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
 		<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.min.js"></script>
 		<script src="app/lib/moment.min.js"></script>


### PR DESCRIPTION
From firefox 39 (now in beta, it will be the next release), all css an js resources won't be loaded if they are provided by an http connection and your page is provided by a secure https connection.

![Result of css not loaded](https://i.imgur.com/aO3EasY.jpg)
The link in the console for further informations is [this](https://developer.mozilla.org/docs/Security/MixedContent).

By the wat from now on is better to load a resource always on a https connection if it's avaiable.
https://github.com/h5bp/html5-boilerplate/pull/1694
