### PR TITLE
Fixed wrong mime type of calendar download file

### DIFF
--- a/app/controllers/turtleCtrlBeta.js
+++ b/app/controllers/turtleCtrlBeta.js
@@ -59,7 +59,7 @@
 		self.addToCalendar = function() {	
 			var calendarData = createCalendarData();		
 			var calendarLink = document.createElement('a');
-			calendarLink.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(calendarData));
+			calendarLink.setAttribute('href', 'data:text/calendar;charset=utf-8,' + encodeURIComponent(calendarData));
 			calendarLink.setAttribute('download', 'TurtleTimes.ics');
 			
 			calendarLink.style.display = 'none';


### PR DESCRIPTION
Me again!

Just realized I had the wrong mime type on the download, this caused android phones to try and open the file in a text viewing program.
Confirmed this change worked this time! It now opens the downloaded file in the calendar program.
