### PR TITLE
In calendar, add all the events of the current week.

### DIFF
--- a/app/services/turtleFact.js
+++ b/app/services/turtleFact.js
@@ -185,8 +185,11 @@
 			var description = "One Piece Treasure Cruise Turtle Time";
 			var location = "OPTC";
 			var begin, end;
+			var target = ttimes[0].clone().add(1, 'weeks').subtract(4, 'hours');
 
-			for (var i=0; i<2; i++) {
+			for (var i=0; i<ttimes.length; i++) {
+			        if (ttimes[i].isAfter(target))
+				        break;
 				begin = ttimes[i].format();
 				end = ttimes[i].clone().add(30, 'minutes').format();
 				cal.addEvent(subject, description, location, begin, end);


### PR DESCRIPTION
Currently only two events are written in the calendar to be downloaded; usually this would work just fine, but during special events (like this week) where there are multiple turtle times per week, it is not possible to import all of them.

With this fix all the events of the current week will be added to the .ics file. In the future we may think of a UI widget to allow users to specify on how many days they want the ics to be created.
